### PR TITLE
Changed certificate paths to support npm install of module

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const soap = require('soap');
 const fs = require('fs');
 
 const messages = require('./messages');
-const testCert = fs.readFileSync('./certificates/test.ca');
-const prodCert = fs.readFileSync('./certificates/production.ca');
+const testCert = fs.readFileSync(__dirname + '/certificates/test.ca');
+const prodCert = fs.readFileSync(__dirname + '/certificates/production.ca');
 
 const ClientSecurity = require('./ClientSecurity')
 


### PR DESCRIPTION
npm install of module results in the module not finding its own certificates. Added __dirname instead of relative path.

/Users/frebos/Projects/work-in-progress/server/server.js
fs.js:640
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
Error: ENOENT: no such file or directory, open './certificates/test.ca'
